### PR TITLE
fix: remove device class from Body Movement Parameter

### DIFF
--- a/example/mr24hpc1_mmwave_kit.yaml
+++ b/example/mr24hpc1_mmwave_kit.yaml
@@ -455,7 +455,6 @@ sensor:
       - name: "Body Movement Parameter"
         id: movementSigns
         icon: "mdi:human-greeting-variant"
-        device_class: "temperature"
         state_class: "measurement"
 
       - name: "Initialization Status"


### PR DESCRIPTION
The device class was incorrectly set to temperature, causing a warning in Home Assistant. Remove it.